### PR TITLE
Rewrite card extractor

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -2,5 +2,6 @@
   "semi": true,
   "trailingComma": "all",
   "singleQuote": true,
-  "printWidth": 120
+  "printWidth": 120,
+  "endOfLine": "auto"
 }

--- a/package.json
+++ b/package.json
@@ -15,10 +15,8 @@
     "docx": "^6.0.3",
     "dotenv": "^6.2.0",
     "lodash": "^4.17.15",
-    "mammoth": "github:Programmerino/mammoth.js",
-    "node-pandoc-promise": "^0.0.6",
     "sqlite3": "^5.0.0",
-    "tmp-promise": "^3.0.2"
+    "unzipper": "^0.10.11"
   },
   "devDependencies": {
     "@types/cheerio": "^0.22.21",
@@ -26,6 +24,7 @@
     "@types/lodash": "^4.14.157",
     "@types/mongoose": "^5.7.30",
     "@types/node": "^14.0.19",
+    "@types/unzipper": "^0.10.4",
     "@typescript-eslint/eslint-plugin": "^3.6.0",
     "@typescript-eslint/parser": "^3.6.0",
     "babel-node": "^0.0.1-security",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -24,11 +24,12 @@ model Evidence {
   tag      String
   cite     String
   summary  String?
+  spoken   String?
   fulltext String?
   markup   String
-  h1       String?
-  h2       String?
-  h3       String?
+  pocket   String?
+  hat      String?
+  block    String?
 
   File   File? @relation(fields: [fileId], references: [id])
   fileId Int?

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,10 @@
 import { documentToTokens, tokensToMarkup, extractCards, tokensToDocument } from 'app/lib';
 import { promises as fs } from 'fs';
 (async () => {
-  const SAMPLE_FILE = './file.docx'
+  const SAMPLE_FILE = './file.docx';
   try {
     const tokens = await documentToTokens(SAMPLE_FILE);
-    fs.writeFile('./data/tokens.json', JSON.stringify(tokens, null, 4))
+    fs.writeFile('./data/tokens.json', JSON.stringify(tokens, null, 4));
     const markup = tokensToMarkup(tokens);
     const cards = extractCards(tokens);
     await fs.writeFile(
@@ -22,7 +22,7 @@ import { promises as fs } from 'fs';
     fs.writeFile('./output-doc.docx', await tokensToDocument(tokens));
 
     console.log(cards);
-    fs.writeFile("./data/cards.json", JSON.stringify(cards, null, 4))
+    fs.writeFile('./data/cards.json', JSON.stringify(cards, null, 4));
   } catch (error) {
     console.error(error);
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,10 @@
 import { documentToTokens, tokensToMarkup, extractCards, tokensToDocument } from 'app/lib';
 import { promises as fs } from 'fs';
 (async () => {
-  const SAMPLE_FILE = '/Users/arvindb/Downloads/file.docx';
+  const SAMPLE_FILE = './file.docx'
   try {
     const tokens = await documentToTokens(SAMPLE_FILE);
+    fs.writeFile('./data/tokens.json', JSON.stringify(tokens, null, 4))
     const markup = tokensToMarkup(tokens);
     const cards = extractCards(tokens);
     await fs.writeFile(
@@ -21,6 +22,7 @@ import { promises as fs } from 'fs';
     fs.writeFile('./output-doc.docx', await tokensToDocument(tokens));
 
     console.log(cards);
+    fs.writeFile("./data/cards.json", JSON.stringify(cards, null, 4))
   } catch (error) {
     console.error(error);
   }

--- a/src/lib/debate-tools/document.ts
+++ b/src/lib/debate-tools/document.ts
@@ -27,12 +27,12 @@ export const documentToMarkup = async (filepath: string): Promise<string> => {
 
 // Load xml by unzipping docx file, file is regex for file name to look for
 const loadXml = (path: string, file: RegExp): Promise<string> => {
-  return new Promise(resolve => {
-    let data = "";
+  return new Promise((resolve) => {
+    let data = '';
     const stream = fs.createReadStream(path);
     stream
       .pipe(ParseOne(file))
-      .on("data", chunk => data += chunk)
-      .on("end", () => resolve(data))
-  })
-}
+      .on('data', (chunk) => (data += chunk))
+      .on('end', () => resolve(data));
+  });
+};

--- a/src/lib/debate-tools/document.ts
+++ b/src/lib/debate-tools/document.ts
@@ -10,7 +10,7 @@ import fs from 'fs';
 export const documentToTokens = async (filepath: string): Promise<TextBlock[]> => {
   const document = await loadXml(filepath, /document\.xml$/);
   const styles = await loadXml(filepath, /styles\.xml$/);
-  const tokens = markupToTokens(document, styles, { simplifed: false });
+  const tokens = markupToTokens(document, styles, { simplified: true });
   return tokens;
 };
 

--- a/src/lib/debate-tools/markup.ts
+++ b/src/lib/debate-tools/markup.ts
@@ -1,8 +1,9 @@
 import ch from 'cheerio';
-import { TextBlock, getStyles, getStyleByElement, simplifyTokens, tokensToDocument } from './';
+import { union } from 'lodash';
+import { TextBlock, getStyleNameByXml, simplifyTokens, tokensToDocument } from './';
 
-export const markupToDocument = async (markup: string): Promise<Buffer> => {
-  const tokens = markupToTokens(markup, { simplifed: true });
+export const markupToDocument = async (xml: string, styles: string): Promise<Buffer> => {
+  const tokens = markupToTokens(xml, styles, { simplifed: true });
   const buffer = await tokensToDocument(tokens);
   return buffer;
 };
@@ -11,8 +12,8 @@ interface TokensOption {
   simplifed: boolean;
 }
 
-export const markupToTokens = (markup: string, options?: TokensOption): TextBlock[] => {
-  const blocks = tokenize(markup);
+export const markupToTokens = (document: string, styles: string, options?: TokensOption): TextBlock[] => {
+  const blocks = tokenize(document, styles);
   if (options?.simplifed) {
     const simplifedBlocks = blocks.map((block) => simplifyTokens(block));
     return simplifedBlocks;
@@ -20,43 +21,50 @@ export const markupToTokens = (markup: string, options?: TokensOption): TextBloc
   return blocks;
 };
 
-const flattenTree = (tree: any[]): any[] => {
-  const flat = [];
-  const flatten = (nodes: string | any[], flattedNodes: any[]) => {
-    for (let index = 0; index < nodes.length; index += 1) {
-      flattedNodes.push(nodes[index]);
-      if (nodes[index].childNodes !== null) {
-        if (nodes[index].childNodes.length > 0) {
-          flatten(nodes[index].childNodes, flattedNodes);
-        }
-      }
-    }
-  };
-  flatten(tree, flat);
-  return flat;
-};
+const getChild = (el, names: string[]) => names.reduce((acc, name) => {
+  return acc?.children?.find(child => child.name === name)
+}, el)
 
-const tokenize = (markup: string): TextBlock[] => {
-  const blockSelector = getStyles({ block: true }).join(', ');
-  const nodes: TextBlock[] = ch(blockSelector, markup)
+// Extract what formatting applies to block of text
+const getElFormating = (styleEl) => {
+  const styles = getChild(styleEl, ['w:rPr']);
+  if (!styles) return [];
+
+  const highlight = getChild(styles, ['w:highlight']);
+  const bold = getChild(styles, ['w:b']);
+  const underline = getChild(styles, ["w:u"])?.attribs['w:val'];
+
+  let formating = [];
+  if (highlight) formating.push('mark')
+  if (bold && bold.attribs['w:val'] !== '0') formating.push('strong')
+  if (underline && underline !== 'none') formating.push('underline');
+
+  return formating;
+}
+
+const tokenize = (xml: string, styles: string): TextBlock[] => {
+  const s = ch.load(styles, { xmlMode: true });
+  const d = ch.load(xml, { xmlMode: true });
+
+  // Generate map of style names to formatting from styles.xml
+  const xmlStyles = s('w\\:style').get().reduce((acc, node) => {
+    acc[node.attribs["w:styleId"]] = getElFormating(node)
+    return acc
+  }, {});
+
+  const tokens: TextBlock[] = d('w\\:p')
     .get()
     .map((block) => ({
-      format: ch(block).get()[0].name,
-      tokens: flattenTree(ch(block).contents().get())
-        .filter((node) => node.type === 'text')
-        .map((node) => ({
-          text: node.data,
-          format: ch(node)
-            .parentsUntil(blockSelector)
-            .get()
-            .map((el) => getStyleByElement(el.name)),
-        })),
+      format: getStyleNameByXml(getChild(block, ["w:pPr", "w:pStyle"])?.attribs["w:val"]),
+      tokens: ch(block).children('w\\:r').get().map((node) => ({
+        text: ch(node).text(),
+        // combine formatting defined in text block and formatting from style name
+        format: union(
+          getElFormating(node),
+          xmlStyles[getChild(node, ["w:rPr", "w:rStyle"])?.attribs["w:val"]]
+        )
+      }))
     }));
-
-  const tokens = nodes.map(({ format, tokens }) => ({
-    format,
-    tokens: tokens.flatMap((node) => node.text.split('').map((text) => ({ text, format: node.format }))),
-  }));
 
   return tokens;
 };

--- a/src/lib/debate-tools/markup.ts
+++ b/src/lib/debate-tools/markup.ts
@@ -21,9 +21,10 @@ export const markupToTokens = (document: string, styles: string, options?: Token
   return blocks;
 };
 
-const getChild = (el, names: string[]) => names.reduce((acc, name) => {
-  return acc?.children?.find(child => child.name === name)
-}, el)
+const getChild = (el, names: string[]) =>
+  names.reduce((acc, name) => {
+    return acc?.children?.find((child) => child.name === name);
+  }, el);
 
 // Extract what formatting applies to block of text
 const getElFormating = (styleEl) => {
@@ -32,38 +33,40 @@ const getElFormating = (styleEl) => {
 
   const highlight = getChild(styles, ['w:highlight']);
   const bold = getChild(styles, ['w:b']);
-  const underline = getChild(styles, ["w:u"])?.attribs['w:val'];
+  const underline = getChild(styles, ['w:u'])?.attribs['w:val'];
 
-  let formating = [];
-  if (highlight) formating.push('mark')
-  if (bold && bold.attribs['w:val'] !== '0') formating.push('strong')
+  const formating = [];
+  if (highlight) formating.push('mark');
+  if (bold && bold.attribs['w:val'] !== '0') formating.push('strong');
   if (underline && underline !== 'none') formating.push('underline');
 
   return formating;
-}
+};
 
 const tokenize = (xml: string, styles: string): TextBlock[] => {
   const s = ch.load(styles, { xmlMode: true });
   const d = ch.load(xml, { xmlMode: true });
 
   // Generate map of style names to formatting from styles.xml
-  const xmlStyles = s('w\\:style').get().reduce((acc, node) => {
-    acc[node.attribs["w:styleId"]] = getElFormating(node)
-    return acc
-  }, {});
+  const xmlStyles = s('w\\:style')
+    .get()
+    .reduce((acc, node) => {
+      acc[node.attribs['w:styleId']] = getElFormating(node);
+      return acc;
+    }, {});
 
   const tokens: TextBlock[] = d('w\\:p')
     .get()
     .map((block) => ({
-      format: getStyleNameByXml(getChild(block, ["w:pPr", "w:pStyle"])?.attribs["w:val"]),
-      tokens: ch(block).children('w\\:r').get().map((node) => ({
-        text: ch(node).text(),
-        // combine formatting defined in text block and formatting from style name
-        format: union(
-          getElFormating(node),
-          xmlStyles[getChild(node, ["w:rPr", "w:rStyle"])?.attribs["w:val"]]
-        )
-      }))
+      format: getStyleNameByXml(getChild(block, ['w:pPr', 'w:pStyle'])?.attribs['w:val']),
+      tokens: ch(block)
+        .children('w\\:r')
+        .get()
+        .map((node) => ({
+          text: ch(node).text(),
+          // combine formatting defined in text block and formatting from style name
+          format: union(getElFormating(node), xmlStyles[getChild(node, ['w:rPr', 'w:rStyle'])?.attribs['w:val']]),
+        })),
     }));
 
   return tokens;

--- a/src/lib/debate-tools/parse.ts
+++ b/src/lib/debate-tools/parse.ts
@@ -5,13 +5,13 @@ const extractText = (blocks: TextBlock[], styles?: StyleName[]): string => {
   if (!blocks[0]) return;
   return blocks
     .reduce((acc, block) => {
-      // filter tokens by styles
-      const filteredTokens = styles
-        ? block?.tokens.filter(({ format }) => styles.every((style) => format.includes(style)))
-        : block?.tokens;
-      // join text and add spacing
-      const text = filteredTokens.reduce((str, val) => str + `${val.text.trim()} `, '').trim();
-      return acc + text + '\n';
+      // join text and add spacing if skipping tokens
+      const text = block?.tokens.reduce((str, token) => {
+        if (!styles || styles.every(style => token.format.includes(style))) return str + token.text
+        else return str.trim() + ' '
+      }, '');
+
+      return acc.trim() + '\n' + text.trim();
     }, '')
     .trim();
 };
@@ -56,10 +56,11 @@ const parseCard = (doc: TextBlock[], anchor = 0, idx): Partial<EvidenceData> => 
   return {
     tag: extractText([tag]),
     cite: extractText([cite], ['strong']),
-    h1: extractHeading('h1'),
-    h2: extractHeading('h2'),
-    h3: extractHeading('h3'),
+    pocket: extractHeading('pocket'),
+    hat: extractHeading('hat'),
+    block: extractHeading('block'),
     summary: extractText(body, ['underline']),
+    spoken: extractText(body, ['mark']),
     fulltext: extractText(body),
     markup: tokensToMarkup(card),
     index: idx,
@@ -67,6 +68,6 @@ const parseCard = (doc: TextBlock[], anchor = 0, idx): Partial<EvidenceData> => 
 };
 
 export const extractCards = (doc: TextBlock[]): any[] => {
-  const anchors = getIndexesWith(doc, ['h4']);
+  const anchors = getIndexesWith(doc, ['tag']);
   return anchors.map((anchor, i) => parseCard(doc, anchor, i));
 };

--- a/src/lib/debate-tools/parse.ts
+++ b/src/lib/debate-tools/parse.ts
@@ -7,8 +7,8 @@ const extractText = (blocks: TextBlock[], styles?: StyleName[]): string => {
     .reduce((acc, block) => {
       // join text and add spacing if skipping tokens
       const text = block?.tokens.reduce((str, token) => {
-        if (!styles || styles.every(style => token.format.includes(style))) return str + token.text
-        else return str.trim() + ' '
+        if (!styles || styles.every((style) => token.format.includes(style))) return str + token.text;
+        else return str.trim() + ' ';
       }, '');
 
       return acc.trim() + '\n' + text.trim();

--- a/src/lib/debate-tools/parse.ts
+++ b/src/lib/debate-tools/parse.ts
@@ -7,7 +7,7 @@ const extractText = (blocks: TextBlock[], styles?: StyleName[]): string => {
     .reduce((acc, block) => {
       // join text and add spacing if skipping tokens
       const text = block?.tokens.reduce((str, token) => {
-        if (!styles || styles.every((style) => token.format.includes(style))) return str + token.text;
+        if (!styles || styles.every((style) => token.format[style])) return str + token.text;
         else return str.trim() + ' ';
       }, '');
 

--- a/src/lib/debate-tools/styles.ts
+++ b/src/lib/debate-tools/styles.ts
@@ -1,5 +1,6 @@
 import { HeadingLevel, IParagraphOptions, IRunOptions } from 'docx';
 import { findKey, pickBy } from 'lodash';
+import { TokenStyle } from '.';
 
 interface Style {
   block: boolean;
@@ -10,7 +11,9 @@ interface Style {
   docxStyles?: IParagraphOptions | IRunOptions;
 }
 
-export type StyleName = 'pocket' | 'hat' | 'block' | 'tag' | 'text' | 'underline' | 'strong' | 'mark';
+export type SectionStyleName = 'pocket' | 'hat' | 'block' | 'tag' | 'text';
+export type TokenStyleName = 'underline' | 'strong' | 'mark';
+export type StyleName = SectionStyleName | TokenStyleName;
 
 export const styleMap: Record<StyleName, Style> = {
   pocket: {
@@ -92,16 +95,16 @@ export const styleMap: Record<StyleName, Style> = {
   },
 };
 
-export const getStyleNameByXml = (elXmlName: string): StyleName => {
+export const getStyleNameByXml = (elXmlName: string): SectionStyleName => {
   const predicate = ({ xmlName = null }) => elXmlName === xmlName;
-  return (findKey(styleMap, predicate) ?? 'text') as StyleName;
+  return (findKey(styleMap, predicate) ?? 'text') as SectionStyleName;
 };
 
 export const getStyles = (filter: Partial<Style>): StyleName[] => {
   return Object.keys(pickBy(styleMap, filter)) as StyleName[];
 };
 
-export const getDocxStyles = (styleNames: StyleName[]): IParagraphOptions | IRunOptions => {
-  const mergedStyles = styleNames.reduce((acc, key) => ({ ...acc, ...styleMap[key]?.docxStyles }), {});
+export const getDocxStyles = (styleNames: TokenStyle): IParagraphOptions | IRunOptions => {
+  const mergedStyles = Object.keys(styleNames).reduce((acc, key) => ({ ...acc, ...styleMap[key]?.docxStyles }), {});
   return mergedStyles;
 };

--- a/src/lib/debate-tools/styles.ts
+++ b/src/lib/debate-tools/styles.ts
@@ -18,7 +18,7 @@ export const styleMap: Record<StyleName, Style> = {
     heading: true,
     domSelector: ['h1'],
     domElement: 'h1',
-    xmlName: "Heading1",
+    xmlName: 'Heading1',
     docxStyles: {
       heading: HeadingLevel.HEADING_1,
       outlineLevel: 1,
@@ -29,7 +29,7 @@ export const styleMap: Record<StyleName, Style> = {
     heading: true,
     domSelector: ['h2'],
     domElement: 'h2',
-    xmlName: "Heading2",
+    xmlName: 'Heading2',
     docxStyles: {
       heading: HeadingLevel.HEADING_2,
       outlineLevel: 2,
@@ -40,7 +40,7 @@ export const styleMap: Record<StyleName, Style> = {
     heading: true,
     domSelector: ['h3'],
     domElement: 'h3',
-    xmlName: "Heading3",
+    xmlName: 'Heading3',
     docxStyles: {
       heading: HeadingLevel.HEADING_3,
       outlineLevel: 3,
@@ -51,7 +51,7 @@ export const styleMap: Record<StyleName, Style> = {
     heading: true,
     domSelector: ['h4'],
     domElement: 'h4',
-    xmlName: "Heading4",
+    xmlName: 'Heading4',
     docxStyles: {
       heading: HeadingLevel.HEADING_4,
       outlineLevel: 4,
@@ -94,8 +94,8 @@ export const styleMap: Record<StyleName, Style> = {
 
 export const getStyleNameByXml = (elXmlName: string): StyleName => {
   const predicate = ({ xmlName = null }) => elXmlName === xmlName;
-  return (findKey(styleMap, predicate) ?? "text") as StyleName;
-}
+  return (findKey(styleMap, predicate) ?? 'text') as StyleName;
+};
 
 export const getStyles = (filter: Partial<Style>): StyleName[] => {
   return Object.keys(pickBy(styleMap, filter)) as StyleName[];

--- a/src/lib/debate-tools/styles.ts
+++ b/src/lib/debate-tools/styles.ts
@@ -100,11 +100,17 @@ export const getStyleNameByXml = (elXmlName: string): SectionStyleName => {
   return (findKey(styleMap, predicate) ?? 'text') as SectionStyleName;
 };
 
+export const getStyleNameByOutlineLvl = (outlineLvl: number): SectionStyleName => {
+  const predicate = ({ docxStyles = null }) => outlineLvl === docxStyles?.outlineLevel;
+  return (findKey(styleMap, predicate) ?? 'text') as SectionStyleName;
+};
+
 export const getStyles = (filter: Partial<Style>): StyleName[] => {
   return Object.keys(pickBy(styleMap, filter)) as StyleName[];
 };
 
 export const getDocxStyles = (styleNames: TokenStyle): IParagraphOptions | IRunOptions => {
-  const mergedStyles = Object.keys(styleNames).reduce((acc, key) => ({ ...acc, ...styleMap[key]?.docxStyles }), {});
+  const styles = pickBy(styleNames, (el) => el); // Get only styles that are set as true
+  const mergedStyles = Object.keys(styles).reduce((acc, key) => ({ ...acc, ...styleMap[key]?.docxStyles }), {});
   return mergedStyles;
 };

--- a/src/lib/debate-tools/styles.ts
+++ b/src/lib/debate-tools/styles.ts
@@ -6,53 +6,58 @@ interface Style {
   heading: boolean;
   domSelector: string[];
   domElement: string;
+  xmlName?: string;
   docxStyles?: IParagraphOptions | IRunOptions;
 }
 
-export type StyleName = 'h1' | 'h2' | 'h3' | 'h4' | 'p' | 'underline' | 'strong' | 'mark';
+export type StyleName = 'pocket' | 'hat' | 'block' | 'tag' | 'text' | 'underline' | 'strong' | 'mark';
 
 export const styleMap: Record<StyleName, Style> = {
-  h1: {
+  pocket: {
     block: true,
     heading: true,
     domSelector: ['h1'],
     domElement: 'h1',
+    xmlName: "Heading1",
     docxStyles: {
       heading: HeadingLevel.HEADING_1,
       outlineLevel: 1,
     },
   },
-  h2: {
+  hat: {
     block: true,
     heading: true,
     domSelector: ['h2'],
     domElement: 'h2',
+    xmlName: "Heading2",
     docxStyles: {
       heading: HeadingLevel.HEADING_2,
       outlineLevel: 2,
     },
   },
-  h3: {
+  block: {
     block: true,
     heading: true,
     domSelector: ['h3'],
     domElement: 'h3',
+    xmlName: "Heading3",
     docxStyles: {
       heading: HeadingLevel.HEADING_3,
       outlineLevel: 3,
     },
   },
-  h4: {
+  tag: {
     block: true,
     heading: true,
     domSelector: ['h4'],
     domElement: 'h4',
+    xmlName: "Heading4",
     docxStyles: {
       heading: HeadingLevel.HEADING_4,
       outlineLevel: 4,
     },
   },
-  p: {
+  text: {
     block: true,
     heading: false,
     domSelector: ['p'],
@@ -87,10 +92,10 @@ export const styleMap: Record<StyleName, Style> = {
   },
 };
 
-export const getStyleByElement = (elementName: StyleName): StyleName => {
-  const predicate = ({ domSelector }) => domSelector.includes(elementName);
-  return findKey(styleMap, predicate) as StyleName;
-};
+export const getStyleNameByXml = (elXmlName: string): StyleName => {
+  const predicate = ({ xmlName = null }) => elXmlName === xmlName;
+  return (findKey(styleMap, predicate) ?? "text") as StyleName;
+}
 
 export const getStyles = (filter: Partial<Style>): StyleName[] => {
   return Object.keys(pickBy(styleMap, filter)) as StyleName[];

--- a/src/lib/debate-tools/tokens.ts
+++ b/src/lib/debate-tools/tokens.ts
@@ -1,7 +1,6 @@
 import { StyleName, styleMap, getDocxStyles } from './';
 import { Document, Packer, Paragraph, TextRun, IRunOptions, IParagraphOptions } from 'docx';
 import { cloneDeep, isEqual } from 'lodash';
-import ch from 'cheerio';
 import { promises as fs } from 'fs';
 
 export interface TextToken {
@@ -15,7 +14,7 @@ export interface TextBlock {
 }
 
 export const tokensToMarkup = (textBlocks: TextBlock[]): string => {
-  const dom = '';
+  let dom = '';
   textBlocks.forEach(({ format, tokens }) => {
     const { domElement } = styleMap[format];
     dom += `<${domElement}>`;
@@ -25,7 +24,7 @@ export const tokensToMarkup = (textBlocks: TextBlock[]): string => {
         const elName = styleMap[style]?.domElement;
         str = `<${elName}>${str}</${elName}>`;
       });
-      dom += str
+      dom += str;
     });
     dom += `</${domElement}>`;
   });

--- a/src/lib/debate-tools/tokens.ts
+++ b/src/lib/debate-tools/tokens.ts
@@ -15,23 +15,22 @@ export interface TextBlock {
 }
 
 export const tokensToMarkup = (textBlocks: TextBlock[]): string => {
-  const dom = ch.load('<div id="root"></div>');
+  const dom = '';
   textBlocks.forEach(({ format, tokens }) => {
     const { domElement } = styleMap[format];
-    const containerEl = `<${domElement}></${domElement}>`;
-    dom('#root').append(containerEl);
+    dom += `<${domElement}>`;
     tokens.forEach(({ text, format }) => {
       let str = text;
       format.forEach((style) => {
         const elName = styleMap[style]?.domElement;
         str = `<${elName}>${str}</${elName}>`;
       });
-
-      dom('#root').children().last().append(str);
+      dom += str
     });
+    dom += `</${domElement}>`;
   });
 
-  return dom('#root').html();
+  return dom;
 };
 
 export const tokensToDocument = async (textBlocks: TextBlock[]): Promise<Buffer> => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -686,9 +686,9 @@
     "@types/node" "*"
 
 "@types/node@*":
-  version "15.3.0"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-15.3.0.tgz#d6fed7d6bc6854306da3dea1af9f874b00783e26"
-  integrity sha512-8/bnjSZD86ZfpBsDlCIkNXIvm+h6wi9g7IqL+kmFkQ+Wvu3JrasgLElfiPgoo8V8vVfnEi0QVS12gbl94h9YsQ==
+  version "16.11.0"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.11.0.tgz#4b95f2327bacd1ef8f08d8ceda193039c5d7f52e"
+  integrity sha512-8MLkBIYQMuhRBQzGN9875bYsOhPnf/0rgXGo66S2FemHkhbn9qtsz9ywV1iCG+vbjigE4WUNVvw37Dx+L0qsPg==
 
 "@types/node@^14.0.19", "@types/node@^14.0.5":
   version "14.14.45"
@@ -719,6 +719,13 @@
   version "0.0.30"
   resolved "https://registry.yarnpkg.com/@types/strip-json-comments/-/strip-json-comments-0.0.30.tgz#9aa30c04db212a9a0649d6ae6fd50accc40748a1"
   integrity sha512-7NQmHra/JILCd1QqpSzl8+mJRc8ZHz3uDm8YV1Ks9IhK0epEiTw8aIErbvH9PI+6XbqhyIQy3462nEsn7UVzjQ==
+
+"@types/unzipper@^0.10.4":
+  version "0.10.4"
+  resolved "https://registry.yarnpkg.com/@types/unzipper/-/unzipper-0.10.4.tgz#db5be3e1f7d37fdfae290024ffe4f46bdcfa47f2"
+  integrity sha512-mryXpAwwQadmfjKWoR7NXnELZVlU90xTON1v3Pq2AcOmuAPFkPh09E0X8fpbx2zofoR5zmOIxGqmWOhD0qXE7g==
+  dependencies:
+    "@types/node" "*"
 
 "@types/yargs-parser@*":
   version "20.2.0"
@@ -930,7 +937,7 @@ arg@^4.1.0:
   resolved "https://registry.yarnpkg.com/arg/-/arg-4.1.3.tgz#269fc7ad5b8e42cb63c896d5666017261c144089"
   integrity sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==
 
-argparse@^1.0.7, argparse@~1.0.3:
+argparse@^1.0.7:
   version "1.0.10"
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-1.0.10.tgz#bcd6791ea5ae09725e17e5ad988134cd40b3d911"
   integrity sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==
@@ -1581,10 +1588,23 @@ bcrypt-pbkdf@^1.0.0:
   dependencies:
     tweetnacl "^0.14.3"
 
+big-integer@^1.6.17:
+  version "1.6.50"
+  resolved "https://registry.yarnpkg.com/big-integer/-/big-integer-1.6.50.tgz#299a4be8bd441c73dcc492ed46b7169c34e92e70"
+  integrity sha512-+O2uoQWFRo8ysZNo/rjtri2jIwjr3XfeAgRjAUADRqGG+ZITvyn8J1kvXLTaKVr3hhGXk+f23tKfdzmklVM9vQ==
+
 binary-extensions@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.2.0.tgz#75f502eeaf9ffde42fc98829645be4ea76bd9e2d"
   integrity sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==
+
+binary@~0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/binary/-/binary-0.3.0.tgz#9f60553bc5ce8c3386f3b553cff47462adecaa79"
+  integrity sha1-n2BVO8XOjDOG87VTz/R0Yq3sqnk=
+  dependencies:
+    buffers "~0.1.1"
+    chainsaw "~0.1.0"
 
 block-stream@*:
   version "0.0.9"
@@ -1593,7 +1613,7 @@ block-stream@*:
   dependencies:
     inherits "~2.0.0"
 
-bluebird@~3.4.0:
+bluebird@~3.4.1:
   version "3.4.7"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.4.7.tgz#f72d760be09b7f76d08ed8fae98b289a8d05fab3"
   integrity sha1-9y12C+Cbf3bQjtj66Ysomo0F+rM=
@@ -1661,6 +1681,16 @@ buffer-from@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
   integrity sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==
+
+buffer-indexof-polyfill@~1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/buffer-indexof-polyfill/-/buffer-indexof-polyfill-1.0.2.tgz#d2732135c5999c64b277fcf9b1abe3498254729c"
+  integrity sha512-I7wzHwA3t1/lwXQh+A5PbNvJxgfo5r3xulgpYDB5zckTu/Z9oUK9biouBKQUjEqzaz3HnAT6TYoovmE+GqSf7A==
+
+buffers@~0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/buffers/-/buffers-0.1.1.tgz#b24579c3bed4d6d396aeee6d9a8ae7f5482ab7bb"
+  integrity sha1-skV5w77U1tOWru5tmorn9Ugqt7s=
 
 cache-base@^1.0.1:
   version "1.0.1"
@@ -1734,6 +1764,13 @@ caseless@~0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
   integrity sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=
+
+chainsaw@~0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/chainsaw/-/chainsaw-0.1.0.tgz#5eab50b28afe58074d0d58291388828b5e5fbc98"
+  integrity sha1-XqtQsor+WAdNDVgpE4iCi15fvJg=
+  dependencies:
+    traverse ">=0.3.0 <0.4"
 
 chalk@^1.1.3:
   version "1.1.3"
@@ -2148,11 +2185,6 @@ diff@^4.0.1:
   resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.2.tgz#60f3aecb89d5fae520c11aa19efc2bb982aade7d"
   integrity sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==
 
-dingbat-to-unicode@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/dingbat-to-unicode/-/dingbat-to-unicode-1.0.1.tgz#5091dd673241453e6b5865e26e5a4452cdef5c83"
-  integrity sha512-98l0sW87ZT58pU4i61wa2OHwxbiYSbuxsCBozaVnYX2iCnr3bLM3fIes1/ej7h1YdOKuKt/MLs706TVnALA65w==
-
 dir-glob@^2.2.2:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/dir-glob/-/dir-glob-2.2.2.tgz#fa09f0694153c8918b18ba0deafae94769fc50c4"
@@ -2247,12 +2279,12 @@ dotenv@^6.2.0:
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-6.2.0.tgz#941c0410535d942c8becf28d3f357dbd9d476064"
   integrity sha512-HygQCKUBSFl8wKQZBSemMywRWcEDNidvNbjGVyZu3nbZ8qq9ubiPoGLMdRDpfSrpkkm9BXYFkpKxxFX38o/76w==
 
-duck@^0.1.12:
-  version "0.1.12"
-  resolved "https://registry.yarnpkg.com/duck/-/duck-0.1.12.tgz#de7adf758421230b6d7aee799ce42670586b9efa"
-  integrity sha512-wkctla1O6VfP89gQ+J/yDesM0S7B7XLXjKGzXxMDVFg7uEn706niAtyYovKbyq1oT9YwDcly721/iUWoc8MVRg==
+duplexer2@~0.1.4:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/duplexer2/-/duplexer2-0.1.4.tgz#8b12dab878c0d69e3e7891051662a32fc6bddcc1"
+  integrity sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=
   dependencies:
-    underscore "^1.13.1"
+    readable-stream "^2.0.2"
 
 dynamic-dedupe@^0.3.0:
   version "0.3.0"
@@ -2991,6 +3023,11 @@ graceful-fs@^4.1.2, graceful-fs@^4.2.4:
   version "4.2.6"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.6.tgz#ff040b2b0853b23c3d31027523706f1885d76bee"
   integrity sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==
+
+graceful-fs@^4.2.2:
+  version "4.2.8"
+  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.8.tgz#e412b8d33f5e006593cbd3cee6df9f2cebbe802a"
+  integrity sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg==
 
 growly@^1.3.0:
   version "1.3.0"
@@ -4041,13 +4078,6 @@ jszip@*, jszip@^3.1.5:
     readable-stream "~2.3.6"
     set-immediate-shim "~1.0.1"
 
-jszip@~2.5.0:
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/jszip/-/jszip-2.5.0.tgz#7444fd8551ddf3e5da7198fea0c91bc8308cc274"
-  integrity sha1-dET9hVHd8+XacZj+oMkbyDCMwnQ=
-  dependencies:
-    pako "~0.2.5"
-
 kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.2.0:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-3.2.2.tgz#31ea21a734bab9bbb0f32466d893aea51e4a3c64"
@@ -4109,6 +4139,11 @@ lines-and-columns@^1.1.6:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.1.6.tgz#1c00c743b433cd0a4e80758f7b64a57440d9ff00"
   integrity sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=
+
+listenercount@~1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/listenercount/-/listenercount-1.0.1.tgz#84c8a72ab59c4725321480c975e6508342e70937"
+  integrity sha1-hMinKrWcRyUyFIDJdeZQg0LnCTc=
 
 load-json-file@^1.0.0:
   version "1.1.0"
@@ -4176,15 +4211,6 @@ loose-envify@^1.0.0:
   dependencies:
     js-tokens "^3.0.0 || ^4.0.0"
 
-lop@^0.4.1:
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/lop/-/lop-0.4.1.tgz#744f1696ef480e68ce1947fe557b09db5af2a738"
-  integrity sha512-9xyho9why2A2tzm5aIcMWKvzqKsnxrf9B5I+8O30olh6lQU8PH978LqZoI4++37RBgS1Em5i54v1TFs/3wnmXQ==
-  dependencies:
-    duck "^0.1.12"
-    option "~0.2.1"
-    underscore "^1.13.1"
-
 loud-rejection@^1.0.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/loud-rejection/-/loud-rejection-1.6.0.tgz#5b46f80147edee578870f086d04821cf998e551f"
@@ -4218,20 +4244,6 @@ makeerror@1.0.x:
   integrity sha1-4BpckQnyr3lmDk6LlYd5AYT1qWw=
   dependencies:
     tmpl "1.0.x"
-
-"mammoth@github:Programmerino/mammoth.js":
-  version "1.4.16"
-  resolved "https://codeload.github.com/Programmerino/mammoth.js/tar.gz/ffacc92cb54cc64c803df11a22af22eeb4bc74dd"
-  dependencies:
-    argparse "~1.0.3"
-    bluebird "~3.4.0"
-    dingbat-to-unicode "^1.0.1"
-    jszip "~2.5.0"
-    lop "^0.4.1"
-    path-is-absolute "^1.0.0"
-    sax "~1.1.1"
-    underscore "^1.13.1"
-    xmlbuilder "^10.0.0"
 
 map-cache@^0.2.2:
   version "0.2.2"
@@ -4468,11 +4480,6 @@ node-notifier@^8.0.0:
     uuid "^8.3.0"
     which "^2.0.2"
 
-node-pandoc-promise@^0.0.6:
-  version "0.0.6"
-  resolved "https://registry.yarnpkg.com/node-pandoc-promise/-/node-pandoc-promise-0.0.6.tgz#8410de8e42ed966d570ea730a3c9f731a4dc7a1d"
-  integrity sha512-3+8hezyBOaWqUWypHtfv8sPa0Yo0sE/KUvjLN1gm48wrwqG2B45fhgIU73H1adF33FXiXkPeTW3lw5cjicemdg==
-
 node-pre-gyp@^0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.11.0.tgz#db1f33215272f692cd38f03238e3e9b47c5dd054"
@@ -4680,11 +4687,6 @@ onetime@^5.1.0:
   dependencies:
     mimic-fn "^2.1.0"
 
-option@~0.2.1:
-  version "0.2.4"
-  resolved "https://registry.yarnpkg.com/option/-/option-0.2.4.tgz#fd475cdf98dcabb3cb397a3ba5284feb45edbfe4"
-  integrity sha1-/Udc35jcq7PLOXo7pShP60Xtv+Q=
-
 optionator@^0.8.1:
   version "0.8.3"
   resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.8.3.tgz#84fa1d036fe9d3c7e21d99884b601167ec8fb495"
@@ -4781,11 +4783,6 @@ p-try@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.2.0.tgz#cb2868540e313d61de58fafbe35ce9004d5540e6"
   integrity sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==
-
-pako@~0.2.5:
-  version "0.2.9"
-  resolved "https://registry.yarnpkg.com/pako/-/pako-0.2.9.tgz#f3f7522f4ef782348da8161bad9ecfd51bf83a75"
-  integrity sha1-8/dSL073gjSNqBYbrZ7P1Rv4OnU=
 
 pako@~1.0.2:
   version "1.0.11"
@@ -5136,7 +5133,7 @@ read-pkg@^5.2.0:
     parse-json "^5.0.0"
     type-fest "^0.6.0"
 
-readable-stream@^2.0.6, readable-stream@~2.3.6:
+readable-stream@^2.0.2, readable-stream@^2.0.6, readable-stream@~2.3.6:
   version "2.3.7"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.7.tgz#1eca1cf711aef814c04f62252a36a62f6cb23b57"
   integrity sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==
@@ -5406,11 +5403,6 @@ sax@^1.2.4:
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
   integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
 
-sax@~1.1.1:
-  version "1.1.6"
-  resolved "https://registry.yarnpkg.com/sax/-/sax-1.1.6.tgz#5d616be8a5e607d54e114afae55b7eaf2fcc3240"
-  integrity sha1-XWFr6KXmB9VOEUr65Vt+ry/MMkA=
-
 saxes@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/saxes/-/saxes-5.0.1.tgz#eebab953fa3b7608dbe94e5dadb15c888fa6696d"
@@ -5459,6 +5451,11 @@ set-value@^2.0.0, set-value@^2.0.1:
     is-extendable "^0.1.1"
     is-plain-object "^2.0.3"
     split-string "^3.0.1"
+
+setimmediate@~1.0.4:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/setimmediate/-/setimmediate-1.0.5.tgz#290cbb232e306942d7d7ea9b83732ab7856f8285"
+  integrity sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=
 
 shebang-command@^1.2.0:
   version "1.2.0"
@@ -5904,20 +5901,6 @@ throat@^5.0.0:
   resolved "https://registry.yarnpkg.com/throat/-/throat-5.0.0.tgz#c5199235803aad18754a667d659b5e72ce16764b"
   integrity sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA==
 
-tmp-promise@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/tmp-promise/-/tmp-promise-3.0.2.tgz#6e933782abff8b00c3119d63589ca1fb9caaa62a"
-  integrity sha512-OyCLAKU1HzBjL6Ev3gxUeraJNlbNingmi8IrHHEsYH8LTmEuhvYfqvhn2F/je+mjf4N58UmZ96OMEy1JanSCpA==
-  dependencies:
-    tmp "^0.2.0"
-
-tmp@^0.2.0:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.2.1.tgz#8457fc3037dcf4719c251367a1af6500ee1ccf14"
-  integrity sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==
-  dependencies:
-    rimraf "^3.0.0"
-
 tmpl@1.0.x:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/tmpl/-/tmpl-1.0.4.tgz#23640dd7b42d00433911140820e5cf440e521dd1"
@@ -5988,6 +5971,11 @@ tr46@^2.0.2:
   integrity sha512-3n1qG+/5kg+jrbTzwAykB5yRYtQCTqOGKq5U5PE3b0a1/mzo6snDhjGS0zJVJunO0NrT3Dg1MLy5TjWP/UJppg==
   dependencies:
     punycode "^2.1.1"
+
+"traverse@>=0.3.0 <0.4":
+  version "0.3.9"
+  resolved "https://registry.yarnpkg.com/traverse/-/traverse-0.3.9.tgz#717b8f220cc0bb7b44e40514c22b2e8bbc70d8b9"
+  integrity sha1-cXuPIgzAu3tE5AUUwisui7xw2Lk=
 
 tree-kill@^1.2.2:
   version "1.2.2"
@@ -6146,11 +6134,6 @@ unbox-primitive@^1.0.0:
     has-symbols "^1.0.2"
     which-boxed-primitive "^1.0.2"
 
-underscore@^1.13.1:
-  version "1.13.1"
-  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.13.1.tgz#0c1c6bd2df54b6b69f2314066d65b6cde6fcf9d1"
-  integrity sha512-hzSoAVtJF+3ZtiFX0VgfFPHEDRm7Y/QPjGyNo4TVdnDTdft3tr8hEkD25a1jC+TjTuE7tkHGKkhwCgs9dgBB2g==
-
 union-value@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/union-value/-/union-value-1.0.1.tgz#0b6fe7b835aecda61c6ea4d4f02c14221e109847"
@@ -6173,6 +6156,22 @@ unset-value@^1.0.0:
   dependencies:
     has-value "^0.3.1"
     isobject "^3.0.0"
+
+unzipper@^0.10.11:
+  version "0.10.11"
+  resolved "https://registry.yarnpkg.com/unzipper/-/unzipper-0.10.11.tgz#0b4991446472cbdb92ee7403909f26c2419c782e"
+  integrity sha512-+BrAq2oFqWod5IESRjL3S8baohbevGcVA+teAIOYWM3pDVdseogqbzhhvvmiyQrUNKFUnDMtELW3X8ykbyDCJw==
+  dependencies:
+    big-integer "^1.6.17"
+    binary "~0.3.0"
+    bluebird "~3.4.1"
+    buffer-indexof-polyfill "~1.0.0"
+    duplexer2 "~0.1.4"
+    fstream "^1.0.12"
+    graceful-fs "^4.2.2"
+    listenercount "~1.0.1"
+    readable-stream "~2.3.6"
+    setimmediate "~1.0.4"
 
 uri-js@^4.2.2:
   version "4.4.1"
@@ -6376,11 +6375,6 @@ xml@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/xml/-/xml-1.0.1.tgz#78ba72020029c5bc87b8a81a3cfcd74b4a2fc1e5"
   integrity sha1-eLpyAgApxbyHuKgaPPzXS0ovweU=
-
-xmlbuilder@^10.0.0:
-  version "10.1.1"
-  resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-10.1.1.tgz#8cae6688cc9b38d850b7c8d3c0a4161dcaf475b0"
-  integrity sha512-OyzrcFLL/nb6fMGHbiRDuPup9ljBycsdCypwuyg5AAHvyWzGfChJpCXMG88AGTIMFhGZ9RccFN1e6lhg3hkwKg==
 
 xmlchars@^2.2.0:
   version "2.2.0"


### PR DESCRIPTION
Since extracting text with basic formatting is relatively simple, instead of using external libraries, it is much faster to just unzip the .docx file and parse the document.xml from scratch.

Doing it this way is much faster (was able to extract cards from all 370ish files on this years openev in 40 seconds on my 2.4GHz laptop cpu) and is able to extract highlighting data

