### PR TITLE
Improve detection of cite

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "docx": "^6.0.3",
     "dotenv": "^6.2.0",
     "lodash": "^4.17.15",
-    "unzipper": "^0.10.11"
+    "unzipper": "^0.10.11",
     "sqlite3": "^5.0.0",
     "mammoth": "^1.4.19",
     "node-pandoc-promise": "^0.0.6",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -15,6 +15,7 @@ model Evidence {
 
   tag      String
   cite     String?
+  fullcite String?
   summary  String?
   spoken   String?
   fulltext String?

--- a/src/lib/debate-tools/parse.ts
+++ b/src/lib/debate-tools/parse.ts
@@ -44,13 +44,27 @@ const parseCard = (doc: TextBlock[], anchor = 0, idx: number) => {
     assume second block element is the cite,
     everything left is the card body 
    */
-  const [tag, cite, ...body] = card;
+  const tag = card.slice(0, 1);
+  const cite = card.slice(1, 2);
+  const body = card.slice(2);
 
   const extractHeading = (name: StyleName) => extractText([getLastBlockWith(doc, anchor, [name])]);
+  const shortCite = extractText(cite, ['strong']);
+  /* 
+    Quite a few documents have the bolded part of cite in seperate block than rest of cite
+    The cite in seperate block usually contains the author's name at the start, if that is detected move the first block of the body to the cite
+  */
+  if (body.length > 1) {
+    const start = extractText([body[0]]).slice(0, 50);
+    if (shortCite.split(' ').find((word) => start.includes(word))) cite.push(...body.splice(0, 1));
+  }
+  // If card has no body, move anything detected as cite to tag
+  if (!body.length && cite) tag.push(...cite.splice(0, 1));
 
   return {
-    tag: extractText([tag]),
-    cite: extractText([cite], ['strong']),
+    tag: extractText(tag),
+    cite: shortCite,
+    fullcite: extractText(cite),
     pocket: extractHeading('pocket'),
     hat: extractHeading('hat'),
     block: extractHeading('block'),


### PR DESCRIPTION
Small change to cite detection. A good amount of files will have a short version of the cite in one block, then a longer one in the next, which is now handled better. Fixes some false matches in deduplication.